### PR TITLE
Remove reliance on Potato feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 Raincoat is a CLI tool to search torrents using [Jackett](https://github.com/Jackett/Jackett)'s indexers and send them directly to your client.
 
 ### Installation
+
 `pip install raincoat-jackett`
 
 ### Requirements
+
 - Python 3.6+
 - Jackett and configured indexers
 - qBittorrent, Transmission or Deluge
@@ -16,16 +18,18 @@ Raincoat is a CLI tool to search torrents using [Jackett](https://github.com/Jac
 
 #### Parameters
 
- - -k, --key
-   - Specify a Jackett API key
- - -l, --length
-   - Max number of characters displayed in the "Description" column.
- - -L, --limit
-   - Limits the number of results displayed.
- - -c, --config
-   - Specifies a different config path.
- - -s, --sort
-   - Change the sorting criteria. Valid choices are: 'seeders', 'leechers', 'ratio', 'size' and 'description'. Default/not specified is 'seeders'.
+- -k, --key
+  - Specify a Jackett API key
+- -l, --length
+  - Max number of characters displayed in the "Description" column.
+- -L, --limit
+  - Limits the number of results displayed.
+- -c, --config
+  - Specifies a different config path.
+- -s, --sort
+  - Change the sorting criteria. Valid choices are: 'seeders', 'leechers', 'ratio', 'size' and 'description'. Default/not specified is 'seeders'.
+- -i, --indexer
+  - Change the indexer used for your search, in cases where you want to only search one site. Default is "all".
 
 #### Configuration file
 
@@ -33,23 +37,26 @@ Upon installation, a config file is created in your home directory. Before you c
 
 ```json
 {
-	"jackett_apikey":"",
-	"jackett_url":"http://your_jackett_potato_feed",
-	"description_length": 100,
-	"exclude": "words to exclude",
-	"results_limit": 20,
-	"client_url": "http://your_torrent_client_api",
-	"display" : "grid",
-	"torrent_client": "qbittorrent",
-	"torrent_client_username" : "admin",
-	"torrent_client_password" : "admin"
+  "jackett_apikey": "",
+  "jackett_url": "http://your_base_jackett_url",
+  "jacket_indexer": "all",
+  "description_length": 100,
+  "exclude": "words to exclude",
+  "results_limit": 20,
+  "client_url": "http://your_torrent_client_api",
+  "display": "grid",
+  "torrent_client": "qbittorrent",
+  "torrent_client_username": "admin",
+  "torrent_client_password": "admin"
 }
 ```
 
 - jackett_apikey (string)
   - The api key provided by Jackett, found on the dashboard.
 - jackett_url (string)
-  - The jackett Potato feed url. (Not Torznab)
+  - The base url for your jackett instance. (default: http://127.0.0.1:9117)
+- jackett_indexer (string)
+  - The jackett indexer you wish to use for searches.
 - description_length (int)
   - The default description length
 - exclude (string)
@@ -80,4 +87,5 @@ Upon installation, a config file is created in your home directory. Before you c
 All available on Pypi.
 
 # License
+
 This project is licensed under the MIT License

--- a/raincoat/raincoat.py
+++ b/raincoat/raincoat.py
@@ -126,7 +126,7 @@ def download(id):
 def search(search_terms):
     print(f"Searching for \"{search_terms}\"...\n")
     try:
-        r = requests.get(f"{JACKETT_URL}api?passkey={APIKEY}&search={search_terms}")
+        r = requests.get(f"{JACKETT_URL}/api/v2.0/indexers/{JACKETT_INDEXER}/results?apikey={APIKEY}&Query={search_terms}")
         if r.status_code != 200:
             print(f"The request to Jackett failed. ({r.status_code})")
             logger.error(f"The request to Jackett failed. ({r.status_code}) :: {JACKETT_URL}api?passkey={APIKEY}&search={search_terms}")

--- a/raincoat/raincoat.py
+++ b/raincoat/raincoat.py
@@ -140,13 +140,14 @@ def search(search_terms):
     global torrents
     torrents = []
     display_table = []
-    for r in res['results']:
-        if filter_out(r['release_name'], EXCLUDE):
+    for r in res['Results']:
+        if filter_out(r['Title'], EXCLUDE):
             continue
-        if len(r['release_name']) > DESC_LENGTH:
-            r['release_name'] = r['release_name'][0:DESC_LENGTH]
-        torrents.append(torrent(id, r['release_name'].encode(
-            'ascii', errors='ignore'), r['type'], r['seeders'], r['leechers'], r['download_url'], r['size']))
+        if len(r['Title']) > DESC_LENGTH:
+            r['Title'] = r['Title'][0:DESC_LENGTH]
+        download_url = r['MagnetUri'] if r['MagnetUri'] else r['Link']
+        torrents.append(torrent(id, r['Title'].encode(
+            'ascii', errors='ignore'), r['CategoryDesc'], r['Seeders'], r['Peers'], download_url, r['Size']))
         id += 1    
 
     # Sort torrents array

--- a/raincoat/raincoat.py
+++ b/raincoat/raincoat.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 
 # Constants
-VERSION = "0.2"
+VERSION = "0.3"
 APP_NAME = "Raincoat"
 
 parser = argparse.ArgumentParser()

--- a/raincoat/raincoat.py
+++ b/raincoat/raincoat.py
@@ -19,11 +19,12 @@ APP_NAME = "Raincoat"
 
 parser = argparse.ArgumentParser()
 parser.add_argument("search", help="The field to search.")
-parser.add_argument("-k", "--key", help="The Jackett API key")
+parser.add_argument("-k", "--key", help="The Jackett API key.")
 parser.add_argument("-l", "--length", help="Max results description length.", type=int)
 parser.add_argument("-L", "--limit", help="Max number of results.", type=int)
 parser.add_argument("-c", "--config", help="Specify a different config file path.")
 parser.add_argument("-s", "--sort", help="Change sorting criteria.", action="store", dest="sort", choices=['seeders', 'leechers', 'ratio', 'size', 'description'])
+parser.add_argument("-i", "--indexer", help="The Jackett indexer to use for your search.")
 args = parser.parse_args()
 
 # Use default path for the config file and load it initially
@@ -51,6 +52,7 @@ greet(VERSION)
 torrents = []
 APIKEY = cfg['jackett_apikey']
 JACKETT_URL = cfg['jackett_url']
+JACKETT_INDEXER = cfg['jackett_indexer']
 DESC_LENGTH = cfg['description_length']
 EXCLUDE = cfg['exclude']
 RESULTS_LIMIT = cfg['results_limit']
@@ -72,6 +74,10 @@ def set_overrides():
     if args.limit is not None:
         global RESULTS_LIMIT
         RESULTS_LIMIT = args.limit
+
+    if args.indexer is not None:
+        global JACKETT_INDEXER
+        JACKETT_INDEXER = args.key
 
     # Set default sorting
     if args.sort is None:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ class PostInstallCommand(install):
             cfg = open(cfg_path, 'x')
             j = dict(
             jackett_apikey="",
-            jackett_url="",
+            jackett_url="http://127.0.0.1:9117",
+            jackett_indexer="all",
             description_length=100,
             exclude="",
             results_limit=20,


### PR DESCRIPTION
Uses the manual search endpoint instead of the potato endpoint to be able to search more than just movies, based on #2 . Requires minor changes to existing config files.

Additionally expands functionality to allow searching only one indexer, but defaulting to all.