### PR TITLE
Remove call to main() from module init to allow raincoat to be used a library

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,3 @@
+from raincoat.raincoat import main
+
+main()

--- a/raincoat/__init__.py
+++ b/raincoat/__init__.py
@@ -1,3 +1,0 @@
-from .raincoat import main
-
-main()


### PR DESCRIPTION
How you fix this issue is a matter of preference I guess. The `main()` function still gets run when you execute

```
raincoat
```

But you won't be able to run this anymore during development:

```
python -m raincoat
```

Instead you can run

```
python bootstrap.py
```